### PR TITLE
vfs: selectively revert caf updates

### DIFF
--- a/src/vfs/prerelease/ant_driver_defines.h
+++ b/src/vfs/prerelease/ant_driver_defines.h
@@ -46,17 +46,17 @@
 
 // Set the file name the driver creates for the ANT device:
 //   If chip uses separate command and data paths:
-// #define ANT_COMMANDS_DEVICE_NAME             "/dev/smd5"
-// #define ANT_DATA_DEVICE_NAME                 "/dev/smd6"
+#define ANT_COMMANDS_DEVICE_NAME             "/dev/smd5"
+#define ANT_DATA_DEVICE_NAME                 "/dev/smd6"
 // OR
 //   If chip uses one path:
-#define ANT_DEVICE_NAME                      "/dev/ant"
+// #define ANT_DEVICE_NAME                      "/dev/ant"
 
 // Set to the number of bytes of header is for Opcode:
 #define ANT_HCI_OPCODE_SIZE                  0
 
 // Set to the number of bytes of header for channel ID
-#define ANT_HCI_CHANNEL_SIZE                 1
+#define ANT_HCI_CHANNEL_SIZE                 0
 
 // Set to the number of bytes of header is for Data Size:
 #define ANT_HCI_SIZE_SIZE                    1


### PR DESCRIPTION
This partially reverts commit 84f4b5332302793d2a4b2af01328243e8518eb81

None of the "vfs-prerelease" devices got driver/fw updates to support
this version, revert to restore legacy methods.

Change-Id: I6d6cf5626b57015e7aa86f896be287925fef3e4c